### PR TITLE
Fixed to return an element with the getNodeEl method

### DIFF
--- a/src/sl-vue-tree.js
+++ b/src/sl-vue-tree.js
@@ -416,7 +416,7 @@ export default {
     },
 
     getNodeEl(path) {
-      this.getRoot().$el.querySelector(`[path="${JSON.stringify(path)}"]`);
+      return this.getRoot().$el.querySelector(`[path="${JSON.stringify(path)}"]`);
     },
 
     getLastNode() {


### PR DESCRIPTION
It looks like the `getNodeEl` method isn't returning an element.
I fixed it to return the element as it is in the d.ts file.
https://github.com/holiber/sl-vue-tree/blob/8cad1b17c11811b614ec59cbf73880c2367406e1/src/sl-vue-tree.d.ts#L51